### PR TITLE
Add quotes around repo name and add missing quote to end of encryption key

### DIFF
--- a/doc_source/ag-create-repo.md
+++ b/doc_source/ag-create-repo.md
@@ -34,10 +34,10 @@ Run the following command:
 
 ```
 $ aws proton create-repository \
-    --name myrepos/environments \
+    --name "myrepos/environments" \
     --connection-arn "arn:aws:codestar-connections:region-id:123456789012:connection/a1b2c3d4-5678-90ab-cdef-EXAMPLE11111" \
     --provider "GITHUB" \
-    --encryption-key "arn:aws:kms:region-id:123456789012:key/bPxRfiCYEXAMPLEKEY \
+    --encryption-key "arn:aws:kms:region-id:123456789012:key/bPxRfiCYEXAMPLEKEY" \
     --tags key=mytag1,value=value1 key=mytag2,value=value2
 ```
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add quotes around repo name and add missing quote to end of encryption key in the ag-create-repo.md page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
