### PR TITLE
fix manifest.yaml syntax for codebuild

### DIFF
--- a/doc_source/ag-infrastructure-tmp-files-codebuild.md
+++ b/doc_source/ag-infrastructure-tmp-files-codebuild.md
@@ -23,7 +23,7 @@ The following manifest file specifies CodeBuild provisioning, and includes the c
 infrastructure:
   templates:
     - rendering_engine: codebuild
-      codebuild:
+      settings:
         image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         runtimes:
           nodejs: 16
@@ -34,7 +34,7 @@ infrastructure:
           - npm run cdk deploy -- --require-approval never --outputs-file proton-outputs.json
           - jq 'to_entries | map_values(.value) | add | to_entries | map({key:.key, valueString:.value})' < proton-outputs.json > outputs.json
           - aws proton notify-resource-deployment-status-change --resource-arn $RESOURCE_ARN --status IN_PROGRESS --outputs file://./outputs.json
-        deprovisioning:
+        deprovision:
           - npm install
           - npm run build
           - npm run cdk destroy


### PR DESCRIPTION
Fixing two typos in manifest.yaml that block template registration. Correct syntax taken from [proton-codebuild-provisioning-examples](https://github.com/aws-containers/proton-codebuild-provisioning-examples/blob/main/cdk/environment-templates/vpc-ecs-cluster/v1/infrastructure/manifest.yaml)

*Issue #, if available:*

*Description of changes:*

When using this example manifest as a starting point, users will receive the following errors:
```
Cannot read infrastructure/manifest.yaml due to invalid YAML syntax (Invalid property: [codebuild]. Valid property names: [file, rendering_engine, settings, template_language])
```

```
Cannot read infrastructure/manifest.yaml due to invalid YAML syntax (Missing property [deprovision])
```

Fixing the example to contain the correct syntax members.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
